### PR TITLE
Skip accounts that error

### DIFF
--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -168,9 +168,12 @@ const handleDownloadAllAccountBalances = async () => {
       onProgress: throttledSendDownloadBalancesProgress,
     });
 
+    const successAccounts = balancesByAccount.filter(({ balances }) => balances.length > 0);
+    const errorAccounts = balancesByAccount.filter(({ balances }) => balances.length === 0);
+
     // combine CSV for each account into one zip file
     const zip = new JSZip();
-    balancesByAccount.forEach(({ accountName, balances }) => {
+    successAccounts.forEach(({ accountName, balances }) => {
       zip.file(`${accountName}.csv`, formatBalancesAsCSV(balances, accountName));
     });
 
@@ -185,6 +188,8 @@ const handleDownloadAllAccountBalances = async () => {
       action: Action.DownloadBalancesComplete,
       payload: {
         outcome: ResponseStatus.Success,
+        successCount: successAccounts.length,
+        errorCount: errorAccounts.length,
       },
     });
   } catch (e) {

--- a/src/shared/lib/__tests__/promises.test.ts
+++ b/src/shared/lib/__tests__/promises.test.ts
@@ -1,5 +1,5 @@
 import delay from '@root/src/shared/lib/delay';
-import { withRateLimit } from '@root/src/shared/lib/promises';
+import { withDefaultOnError, withRateLimit } from '@root/src/shared/lib/promises';
 
 describe('withRateLimit', () => {
   it('spaces out requests', async () => {
@@ -13,5 +13,19 @@ describe('withRateLimit', () => {
     const endTime = new Date().getTime();
 
     expect(endTime - startTime).toBeGreaterThan(1000);
+  });
+});
+
+describe('withDefaultOnError', () => {
+  it('returns default value when promise rejects', async () => {
+    const func = async () => {
+      await delay(100);
+      throw new Error();
+
+      return 'test';
+    };
+
+    const result = await withDefaultOnError('errored')(func());
+    expect(result).toEqual('errored');
   });
 });

--- a/src/shared/lib/promises.ts
+++ b/src/shared/lib/promises.ts
@@ -40,3 +40,8 @@ export const resolveSequential = async <T>(requests: (() => Promise<T>)[]): Prom
 
   return results;
 };
+
+export const withDefaultOnError =
+  <T>(defaultValue: T) =>
+  (promise: Promise<T>): Promise<T> =>
+    promise.catch(() => defaultValue);


### PR DESCRIPTION
This makes it so we skip accounts that error for any reason when downloading balances. At the end we'll report how many accounts succeeded and how many failed:

![image](https://github.com/monarchmoney/mint-export-extension/assets/3914217/36c8d2ad-e327-4198-8f15-7d4dc3639b13)
