### PR TITLE
Add Sentry by default for error tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "tslib": "^2.6.2",
     "typescript": "4.9.5",
     "vite": "3.2.7",
-    "vite-plugin-conditional-compiler": "^0.2.1",
     "ws": "8.13.0"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,9 +184,6 @@ devDependencies:
   vite:
     specifier: 3.2.7
     version: 3.2.7(@types/node@18.15.11)(sass@1.62.1)
-  vite-plugin-conditional-compiler:
-    specifier: ^0.2.1
-    version: 0.2.1(rollup@2.79.1)(vite@3.2.7)(webpack@5.89.0)
   ws:
     specifier: 8.13.0
     version: 8.13.0
@@ -549,14 +546,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.2)
       '@babel/types': 7.23.0
-    dev: true
-
-  /@babel/runtime-corejs3@7.23.2:
-    resolution: {integrity: sha512-54cIh74Z1rp4oIjsHjqN+WM4fMyCBYe+LpZ9jWm51CZ1fbH3SkAzQD/3XLoNkjbJ7YEmjobLXyvQrFypRHOrXw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      core-js-pure: 3.33.2
-      regenerator-runtime: 0.14.0
     dev: true
 
   /@babel/runtime@7.23.2:
@@ -2701,11 +2690,6 @@ packages:
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-    dev: true
-
-  /core-js-pure@3.33.2:
-    resolution: {integrity: sha512-a8zeCdyVk7uF2elKIGz67AjcXOxjRbwOLz8SbklEso1V+2DoW4OkAMZN9S9GBgvZIaqQi/OemFX4OiSoQEmg1Q==}
-    requiresBuild: true
     dev: true
 
   /core-util-is@1.0.3:
@@ -5830,13 +5814,6 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: false
 
-  /magic-string@0.30.5:
-    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
-
   /make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -8015,40 +7992,6 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unplugin-preprocessor-directives@0.0.8(rollup@2.79.1)(vite@3.2.7)(webpack@5.89.0):
-    resolution: {integrity: sha512-SC1UJ1rYz4c1wBSN1BdFPYuWH7B7T3JVPA7hP6gfQSxiLcFcfW0BJ4L19peCos9fcQuF91W6k2iQ9g4RcXjeCQ==}
-    peerDependencies:
-      '@nuxt/kit': ^3
-      '@nuxt/schema': ^3
-      '@rspack/core': '*'
-      esbuild: '*'
-      rollup: ^3
-      vite: '>=3'
-      webpack: ^4 || ^5
-    peerDependenciesMeta:
-      '@nuxt/kit':
-        optional: true
-      '@nuxt/schema':
-        optional: true
-      '@rspack/core':
-        optional: true
-      esbuild:
-        optional: true
-      rollup:
-        optional: true
-      vite:
-        optional: true
-      webpack:
-        optional: true
-    dependencies:
-      magic-string: 0.30.5
-      rollup: 2.79.1
-      unplugin: 1.5.0
-      vite: 3.2.7(@types/node@18.15.11)(sass@1.62.1)
-      webpack: 5.89.0
-      xregexp: 5.1.1
-    dev: true
-
   /unplugin@1.0.1:
     resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
     dependencies:
@@ -8057,15 +8000,6 @@ packages:
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.5.0
     dev: false
-
-  /unplugin@1.5.0:
-    resolution: {integrity: sha512-9ZdRwbh/4gcm1JTOkp9lAkIDrtOyOxgHmY7cjuwI8L/2RTikMcVG25GsZwNAgRuap3iDw2jeq7eoqtAsz5rW3A==}
-    dependencies:
-      acorn: 8.10.0
-      chokidar: 3.5.3
-      webpack-sources: 3.2.3
-      webpack-virtual-modules: 0.5.0
-    dev: true
 
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
@@ -8138,20 +8072,6 @@ packages:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
-    dev: true
-
-  /vite-plugin-conditional-compiler@0.2.1(rollup@2.79.1)(vite@3.2.7)(webpack@5.89.0):
-    resolution: {integrity: sha512-AeYXykxLZW0EmT0xMxozvAe+8EN/8tEmQ49gcVuuKaKqn8eYuuWM0AwD9yGUnfB8/lM16K/XyumvhaW4IWmMjQ==}
-    dependencies:
-      unplugin-preprocessor-directives: 0.0.8(rollup@2.79.1)(vite@3.2.7)(webpack@5.89.0)
-    transitivePeerDependencies:
-      - '@nuxt/kit'
-      - '@nuxt/schema'
-      - '@rspack/core'
-      - esbuild
-      - rollup
-      - vite
-      - webpack
     dev: true
 
   /vite@3.2.7(@types/node@18.15.11)(sass@1.62.1):
@@ -8239,6 +8159,7 @@ packages:
 
   /webpack-virtual-modules@0.5.0:
     resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
+    dev: false
 
   /webpack@5.89.0:
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
@@ -8462,12 +8383,6 @@ packages:
 
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-    dev: true
-
-  /xregexp@5.1.1:
-    resolution: {integrity: sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==}
-    dependencies:
-      '@babel/runtime-corejs3': 7.23.2
     dev: true
 
   /y18n@5.0.8:

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -1,6 +1,11 @@
 import { ResponseStatus } from '@root/src/pages/popup/Popup';
 import { ErrorCode } from '@root/src/shared/constants/error';
 import { Action } from '@root/src/shared/hooks/useMessage';
+import {
+  fetchDailyBalancesForAllAccounts,
+  formatBalancesAsCSV,
+} from '@root/src/shared/lib/accounts';
+import { throttle } from '@root/src/shared/lib/events';
 import stateStorage from '@root/src/shared/storages/stateStorage';
 import {
   concatenateCSVPages,
@@ -8,23 +13,13 @@ import {
   fetchTransactionsTotalCount,
 } from '@src/shared/lib/transactions';
 import apiKeyStorage from '@src/shared/storages/apiKeyStorage';
-import reloadOnUpdate from 'virtual:reload-on-update-in-background-script';
-import {
-  fetchDailyBalancesForAllAccounts,
-  formatBalancesAsCSV,
-} from '@root/src/shared/lib/accounts';
 import JSZip from 'jszip';
+import reloadOnUpdate from 'virtual:reload-on-update-in-background-script';
 import 'webextension-polyfill';
-import { throttle } from '@root/src/shared/lib/events';
-
-// #v-ifdef VITE_SENTRY_DSN
-// We don't want to track any user data, so we only initialize Sentry in development
-// (it's where we have VITE_SENTRY_DSN defined)
 
 import * as Sentry from '@sentry/browser';
 
-// https://github.com/getsentry/sentry-javascript/issues/5289#issuecomment-1368705821
-// @ts-ignore - Just for local development
+// @ts-ignore - https://github.com/getsentry/sentry-javascript/issues/5289#issuecomment-1368705821
 Sentry.WINDOW.document = {
   visibilityState: 'hidden',
   addEventListener: () => {},
@@ -39,7 +34,6 @@ Sentry.init({
   tracesSampleRate: 1.0,
   ignoreErrors: [/ResizeObserver/, 'ResizeObserver loop limit exceeded', 'Network request failed'],
 });
-// #v-endif
 
 reloadOnUpdate('pages/background');
 
@@ -60,14 +54,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
 
-  // #v-ifdef VITE_SENTRY_DSN
   const transaction = Sentry.startTransaction({
     name: message.action,
     op: 'background',
   });
 
   Sentry.configureScope((scope) => scope.setSpan(transaction));
-  // #v-endif
 
   console.log(`Received message with action: ${message.action}`);
 
@@ -83,9 +75,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     throw new Error('Debug error');
   }
 
-  // #v-ifdef VITE_SENTRY_DSN
   transaction.finish();
-  // #v-endif
 
   return true; // indicates we will send a response asynchronously
 });

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -33,6 +33,13 @@ Sentry.init({
   integrations: [new Sentry.BrowserTracing()],
   tracesSampleRate: 1.0,
   ignoreErrors: [/ResizeObserver/, 'ResizeObserver loop limit exceeded', 'Network request failed'],
+  beforeSend(event) {
+    if (event.user) {
+      // Do not send any user data to Sentry
+      delete event.user;
+    }
+    return event;
+  },
 });
 
 reloadOnUpdate('pages/background');

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -1,20 +1,17 @@
-import { useEffect, useState, useMemo } from 'react';
-import apiKeyStorage from '@src/shared/storages/apiKeyStorage';
-import withSuspense from '@src/shared/hoc/withSuspense';
-import withErrorBoundary from '@src/shared/hoc/withErrorBoundary';
-import { Action, useMessageSender } from '@src/shared/hooks/useMessage';
-import { getUserData } from '@src/shared/lib/auth';
-import { ErrorCode } from '@src/shared/constants/error';
-import PopupContainer from '@src/components/popup/PopupContainer';
+import ErrorBoundary from '@root/src/components/ErrorBoundary';
+import Text from '@root/src/components/Text';
 import DefaultButton from '@root/src/components/button/DefaultButton';
 import PopupContext from '@root/src/pages/popup/context';
-import Text from '@root/src/components/Text';
 import stateStorage from '@root/src/shared/storages/stateStorage';
-import ErrorBoundary from '@root/src/components/ErrorBoundary';
+import PopupContainer from '@src/components/popup/PopupContainer';
+import { ErrorCode } from '@src/shared/constants/error';
+import withErrorBoundary from '@src/shared/hoc/withErrorBoundary';
+import withSuspense from '@src/shared/hoc/withSuspense';
+import { Action, useMessageSender } from '@src/shared/hooks/useMessage';
+import { getUserData } from '@src/shared/lib/auth';
+import apiKeyStorage from '@src/shared/storages/apiKeyStorage';
+import { useEffect, useMemo, useState } from 'react';
 
-// #v-ifdef VITE_SENTRY_DSN
-// We don't want to track any user data, so we only initialize Sentry in development
-// (it's where we have VITE_SENTRY_DSN defined)
 import * as Sentry from '@sentry/react';
 
 Sentry.init({
@@ -23,7 +20,6 @@ Sentry.init({
   release: import.meta.env.VITE_COMMIT_SHA,
   tracesSampleRate: 1.0,
 });
-// #v-endif
 
 export enum ResponseStatus {
   RequireAuth = 'require_auth',

--- a/src/pages/popup/Popup.tsx
+++ b/src/pages/popup/Popup.tsx
@@ -19,6 +19,13 @@ Sentry.init({
   environment: import.meta.env.MODE,
   release: import.meta.env.VITE_COMMIT_SHA,
   tracesSampleRate: 1.0,
+  beforeSend(event) {
+    if (event.user) {
+      // Do not send any user data to Sentry
+      delete event.user;
+    }
+    return event;
+  },
 });
 
 export enum ResponseStatus {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,6 @@ import customDynamicImport from './utils/plugins/custom-dynamic-import';
 import addHmr from './utils/plugins/add-hmr';
 import watchRebuild from './utils/plugins/watch-rebuild';
 import manifest from './manifest';
-import ConditionalCompile from 'vite-plugin-conditional-compiler';
 
 const rootDir = resolve(__dirname);
 const srcDir = resolve(rootDir, 'src');
@@ -32,7 +31,6 @@ export default defineConfig({
     },
   },
   plugins: [
-    ConditionalCompile(),
     react(),
     makeManifest(manifest, {
       isDev,
@@ -41,8 +39,7 @@ export default defineConfig({
     customDynamicImport(),
     addHmr({ background: enableHmrInBackgroundScript, view: true }),
     watchRebuild(),
-    isProduction &&
-      process.env.SENTRY_DSN &&
+    process.env.SENTRY_DSN &&
       sentryVitePlugin({
         org: 'monarch',
         project: 'mint-data-exporter',


### PR DESCRIPTION
Use Sentry to track errors, but don't send any user data (we modify the `beforeSend` callback to delete `event.user`)