### PR TITLE
Do not export future balances

### DIFF
--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -147,7 +147,9 @@ const fetchDailyBalancesForMonthIntervals = async ({
                 type: 'CUSTOM',
                 startDate: start.toISODate(),
                 // end is really the start of the next month, so subtract one day
-                endDate: end.minus({ day: 1 }).toISODate(),
+                endDate: end < DateTime.now()
+                    ? end.minus({ day: 1 }).toISODate()
+                    : DateTime.now().toISODate(),
               },
               overrideApiKey,
             })


### PR DESCRIPTION
The month-by-month API export results in future dates in the current month rather than ending at today's date. If the current data were imported in the future it would wipe out accurate balance data collected by Monarch and result in an unexpected plateau in the balance charts since the Mint API just carries forward the last balance to future dates.

Additionally, Monarch shows an unhelpful error message when it hits future dates in a balance history import: 
> Error parsing value '2023-11-17' on row 3922.