### PR TITLE
Fixed export of accounts that have the same name

### DIFF
--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -165,8 +165,12 @@ const handleDownloadAllAccountBalances = async (sendResponse: () => void) => {
 
     // combine CSV for each account into one zip file
     const zip = new JSZip();
+    const seenAccountNames = {};
     successAccounts.forEach(({ accountName, balances }) => {
-      zip.file(`${accountName}.csv`, formatBalancesAsCSV(balances, accountName));
+      const seenCount = (seenAccountNames[accountName] = (seenAccountNames[accountName] || 0) + 1);
+      // If there are multiple accounts with the same name, export both with distinct filenames
+      const disambiguation = seenCount > 1 ? ` (${seenCount - 1})` : '';
+      zip.file(`${accountName}${disambiguation}.csv`, formatBalancesAsCSV(balances, accountName));
     });
 
     const zipFile = await zip.generateAsync({ type: 'base64' });


### PR DESCRIPTION
Throughout the years I accumulated a couple accounts in Mint that popped in perhaps from sync errors or credit card fraud replacement, but they happen to have the same name. In these scenarios, the zip file contains the transactions of only one of the duplicated accounts. In my case, it is an old loan where one of the accounts has no trend data and the other has a few months of balance history. Duplicate names resulted in only one CSV file in the zip – guess which of those accounts I got 😆 

Since it is a fully automated process and users are unlikely to even be aware of duplicate account names, I have deduped the zip files. File naming follows the macOS standard where the first duplicate is marked `(1)`, then `(2)`, etc. This could have been done earlier in `fetchAccounts` so that the file name matches the CSV account name column but I think that would lead to more issues. For example, a user might expect the account name column to match Mint exactly, or one of the accounts could fail to export and you would be left with just the disambiguated one.