### PR TITLE
Optimize fetch performance, particularly for old zeroed accounts

### DIFF
--- a/src/shared/lib/__tests__/accounts.test.ts
+++ b/src/shared/lib/__tests__/accounts.test.ts
@@ -81,6 +81,58 @@ describe('formatBalancesAsCSV', () => {
 "2020-01-01",""
 `);
   });
+
+  it('trims trailing zero balances', () => {
+    const result = formatBalancesAsCSV([
+      {
+        amount: 123.45,
+        date: '2020-01-01',
+        type: '',
+      },
+      {
+        amount: 234.56,
+        date: '2020-01-02',
+        type: '',
+      },
+      {
+        amount: 0,
+        date: '2020-01-03',
+        type: '',
+      },
+      {
+        amount: 0,
+        date: '2020-01-04',
+        type: '',
+      },
+    ]);
+    expect(result).toEqual(`"Date","Amount"
+"2020-01-01","123.45"
+"2020-01-02","234.56"
+`);
+  });
+
+  it('leaves one row if all balances are zero', () => {
+    const result = formatBalancesAsCSV([
+      {
+        amount: 0,
+        date: '2020-01-01',
+        type: '',
+      },
+      {
+        amount: 0,
+        date: '2020-01-02',
+        type: '',
+      },
+      {
+        amount: 0,
+        date: '2020-01-03',
+        type: '',
+      },
+    ]);
+    expect(result).toEqual(`"Date","Amount"
+"2020-01-01","0"
+`);
+  });
 });
 
 describe('fetchDailyBalancesForAllAccounts', () => {

--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -365,11 +365,17 @@ export const fetchAccounts = async ({
 
 export const formatBalancesAsCSV = (balances: TrendEntry[], accountName?: string) => {
   const header = ['Date', 'Amount', accountName && 'Account Name'].filter(Boolean);
-  const rows = balances.map(({ date, amount }) => [
-    date,
-    amount,
-    ...(accountName ? [accountName] : []),
-  ]);
+  const maybeAccountColumn: [string?] = accountName ? [accountName] : [];
+  // remove zero balances from the end of the report leaving just the first row if all are zero
+  const rows = balances.reduceRight(
+    (acc, { date, amount }, index) => {
+      if (acc.length || amount !== 0 || index === 0) {
+        acc.unshift([date, amount, ...maybeAccountColumn]);
+      }
+      return acc;
+    },
+    [] as [string, number, string?][],
+  );
 
   return formatCSV([header, ...rows]);
 };

--- a/src/shared/lib/constants.ts
+++ b/src/shared/lib/constants.ts
@@ -14,3 +14,6 @@ export const UTM_URL_PARAMETERS = {
 
 // we may need to increase this, need to test more
 export const MINT_RATE_LIMIT_DELAY_MS = 50;
+
+// The Mint API returns daily activity when the date range is 43 days or fewer.
+export const MINT_DAILY_TRENDS_MAX_DAYS = 43;


### PR DESCRIPTION
Submitting for discussion to fix #17, there are a lot of factors to consider here but let's just say this is not exclusively about optimization. 

## Fewer requests for all accounts 

This pull request changes the daily balance API requests from 1-per-month to 1-per-43 days. This magic number is the largest range where the API will still return daily granularity. The larger batches reduce the total number of API requests by about 30%.

## Much fewer requests for zeroed accounts

For a 10 year old account that had 1 month of activity then went forever zero it is far more efficient to pull only a couple months rather than 10 years of zeroes from the Mint API.

The more nuanced reason is that we're going to be importing these files into Monarch. Consider a 401k account that upon change of employment was rolled over into an IRA. In Monarch I prefer to see the balance of that IRA from day one even though it was technically a different account at that time. If the 401k CSV contains zeroes all the way through to today's date I have to be very careful when importing those balances to choose the old defunct account first, then upload the new account which will overwrite the zeroes. Imported in the opposite order, the zeroes in the 401k CSV would overwrite my IRA balance history.

I also have one account that went through no fewer than 5 such transitions, some at the financial account level and some just from Mint cycling connection providers. In that case the advice to upload the oldest one first is pretty tough.

### ❓ Discussion: What should the CSV include for zeroed accounts?

My opinion is that after pulling the daily data, all trailing zero balances should be removed from the CSV. 

In my Mint export extension I implemented this differently, leaving the last zero as a way to see that the balance went to zero. I think it was well-intentioned, the idea was that showing a zero there would reinforce that the balance went to zero. However that is actually not good for the use case above where the balance was never actually zero, Mint just transitioned the connection one day. We can't distinguish "the balance went to zero" from "Mint shut down the connection" so including a trailing zero in the CSV may not even be representative of the actual balance.

### ❓ Discussion: What about accounts that have no transactions at all?

The CSV has two pieces of useful information - the balance and the date. If we remove **all** zero balance rows then there is no data left for accounts with no transactions. I think that trimming zero balance rows from the end of the CSV should preserve the first and only row in the CSV. Then at least you can see the date the account was created in Mint even if there was never a balance.

### What does this pull request do?

Currently it includes about a month of zeroes for each account because any removal of trailing zeroes is pending discussion. See test cases for the specific date intervals that are requested in each scenario. 

I found in my own accounts a few cases where the Mint Trends chart showed a nonzero balance month followed by a zero balance month even though there were nonzero daily balances a week or two into that zero balance month. So the entire first zero balance month is requested from the daily API for safety.

I also think the refactoring helps to avoid some confusion in reading the code between the monthly trend data coming from Mint and the daily trend data that we're gathering (renamed from "months" to "periods").

## How does this affect the progress bar?

The progress bar still works perfectly and has not been changed in this PR. It is tracking the total amount of data that needs to be downloaded, not the total number of accounts. However, now the amount of data required for each account is far more variant. In my account, the progress bar was nearly full with less than 75% of accounts processed because the last couple dozen have very little history.
<img width="337" alt="Screenshot 2023-11-15 at 6 36 51 PM" src="https://github.com/monarchmoney/mint-export-extension/assets/507058/466a1183-992b-4891-8350-670ef14fb2fc">

Oh yeah and progress goes brrrrr now, takes much less time to export all 97 accounts.
