### PR TITLE
Fix last day missing in each interval

### DIFF
--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -169,11 +169,7 @@ const fetchDailyBalancesForAccount = async ({
               dateFilter: {
                 type: 'CUSTOM',
                 startDate: start.toISODate(),
-                // end is really the start of the next month, so subtract one day
-                endDate:
-                  end < DateTime.now()
-                    ? end.minus({ day: 1 }).toISODate()
-                    : DateTime.now().toISODate(),
+                endDate: end < DateTime.now() ? end.toISODate() : DateTime.now().toISODate(),
               },
               overrideApiKey,
             })


### PR DESCRIPTION
Caught this while working on trend exports. I was exporting just one month of trend data and noticed the last day was missing. I believe this bug caused the last day in each 43-day interval to be skipped, it is a line of code that was relevant to the month-by-month exports.