### PR TITLE
Export any time-based trend

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -24,6 +24,7 @@ const manifest: chrome.runtime.ManifestV3 = {
   web_accessible_resources: [
     {
       resources: [
+        'src/pages/content/*.js',
         'assets/js/*.js',
         'assets/css/*.css',
         'icon-128.png',
@@ -32,6 +33,14 @@ const manifest: chrome.runtime.ManifestV3 = {
         'icon-beta-128.png',
       ],
       matches: ['https://mint.intuit.com/*'],
+    },
+  ],
+  content_scripts: [
+    {
+      // Must load on any page due to SPA navigation but only activates on /trends
+      matches: ['https://mint.intuit.com/*'],
+      js: ['src/pages/content-bootstrap/index.js'],
+      css: [],
     },
   ],
 };

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -170,7 +170,10 @@ const handleDownloadAllAccountBalances = async (sendResponse: () => void) => {
       const seenCount = (seenAccountNames[accountName] = (seenAccountNames[accountName] || 0) + 1);
       // If there are multiple accounts with the same name, export both with distinct filenames
       const disambiguation = seenCount > 1 ? ` (${seenCount - 1})` : '';
-      zip.file(`${accountName}${disambiguation}.csv`, formatBalancesAsCSV(balances, accountName));
+      zip.file(
+        `${accountName}${disambiguation}.csv`,
+        formatBalancesAsCSV({ balances, accountName }),
+      );
     });
 
     const zipFile = await zip.generateAsync({ type: 'base64' });

--- a/src/pages/content/bootstrap.ts
+++ b/src/pages/content/bootstrap.ts
@@ -1,0 +1,6 @@
+(async () => {
+  // Load the content script with an async import, otherwise it will not be able to use module
+  // import syntax.
+  const src = chrome.runtime.getURL('src/pages/content/index.js');
+  await import(src);
+})();

--- a/src/pages/content/content-action.ts
+++ b/src/pages/content/content-action.ts
@@ -1,0 +1,4 @@
+export enum ContentAction {
+  DownloadTrendBalances = 'DOWNLOAD_TREND_BALANCES',
+  DownloadTrendBalancesProgress = 'DOWNLOAD_TREND_BALANCES_PROGRESS',
+}

--- a/src/pages/content/export.ts
+++ b/src/pages/content/export.ts
@@ -1,0 +1,46 @@
+import { Message } from '../../shared/hooks/useMessage';
+import { TrendBalanceHistoryCallbackProgress, TrendState } from '../../shared/lib/accounts';
+import { ContentAction } from './content-action';
+
+/** Request daily history for the current trend and download as a CSV file. */
+export const exportDailyHistory = ({
+  trend,
+  onProgress,
+}: {
+  trend: TrendState;
+  onProgress?: (completed?: number) => void;
+}) =>
+  withProgressMonitor(async () => {
+    const message: Message = {
+      action: ContentAction.DownloadTrendBalances,
+      payload: trend,
+    };
+    await chrome.runtime.sendMessage(message);
+  }, onProgress);
+
+/**
+ * Performs the action with progress reporting that guarantees no stray progress updates after
+ * completion of the action.
+ */
+const withProgressMonitor = async (
+  action: () => Promise<void>,
+  onProgress?: (completed?: number) => void,
+) => {
+  const listener = (message: Message<TrendBalanceHistoryCallbackProgress>) => {
+    switch (message.action) {
+      case ContentAction.DownloadTrendBalancesProgress:
+        onProgress?.(+message.payload.completePercentage);
+        break;
+    }
+  };
+
+  chrome.runtime.onMessage.addListener(listener);
+  onProgress?.(0);
+
+  try {
+    await action();
+  } finally {
+    chrome.runtime.onMessage.removeListener(listener);
+    onProgress?.();
+  }
+};

--- a/src/pages/content/get-element.ts
+++ b/src/pages/content/get-element.ts
@@ -1,0 +1,14 @@
+/** Waits for selector to match and returns corresponding element. */
+export const getElement = async (selector: string, parent: ParentNode = document) => {
+  return new Promise<Element>((resolve) => {
+    const find = () => {
+      const element = parent.querySelector(selector);
+      if (element) {
+        resolve(element);
+      } else {
+        setTimeout(find, 500);
+      }
+    };
+    find();
+  });
+};

--- a/src/pages/content/index.ts
+++ b/src/pages/content/index.ts
@@ -1,0 +1,76 @@
+import { exportDailyHistory } from './export';
+import { getElement } from './get-element';
+import { whenMintSectionActive } from './mint-navigation';
+import { getCurrentTrendState, isSupportedTrendReport } from './trend-state';
+
+let isExporting = false;
+
+// Export daily balance link to add to the trends page
+const exportDailyLink = document.createElement('a');
+exportDailyLink.innerHTML =
+  '<span style="mix-blend-mode: multiply">Export Daily History to CSV</span>';
+exportDailyLink.id = 'export-daily';
+exportDailyLink.style.borderRadius = '4px';
+exportDailyLink.style.marginLeft = '8px';
+exportDailyLink.addEventListener('click', async (event) => {
+  event.preventDefault();
+  // pointerEvents: none should prevent multiple clicks, but just in case
+  if (!isExporting) {
+    isExporting = true;
+    await exportDailyHistory({
+      trend: getCurrentTrendState(),
+      onProgress: (progress) => {
+        updateExportProgressBar(progress);
+      },
+    });
+    isExporting = false;
+  }
+});
+
+/** Sets the background gradient of the export daily button to indicate data pull progress. */
+export const updateExportProgressBar = (progress?: number) => {
+  if (progress != null) {
+    const percent = progress * 100;
+    exportDailyLink.style.pointerEvents = 'none';
+    exportDailyLink.style.background = `linear-gradient(to right, #1b8381 ${percent}%, #f4f5f8 ${percent}%)`;
+  } else {
+    exportDailyLink.style.pointerEvents = 'unset';
+    exportDailyLink.style.background = 'white';
+  }
+};
+
+/**
+ * Adds the daily export link after Mint's Export CSV link if not already present and updates
+ * its status.
+ */
+const addExportLink = async () => {
+  if (!document.contains(exportDailyLink)) {
+    const exportLink = await getElement('[data-automation-id=export-csv]');
+    exportDailyLink.className = exportLink.className;
+    updateExportProgressBar();
+    if (!document.getElementById('export-daily')) {
+      exportLink.after(exportDailyLink);
+    }
+  }
+  const { reportType } = getCurrentTrendState();
+  if (isSupportedTrendReport(reportType)) {
+    exportDailyLink.style.pointerEvents = 'unset';
+    exportDailyLink.style.opacity = '1';
+  } else {
+    exportDailyLink.style.pointerEvents = 'none';
+    exportDailyLink.style.opacity = '0.25';
+  }
+};
+
+let exportLinkInterval: NodeJS.Timer;
+
+whenMintSectionActive({
+  section: 'trends',
+  onActivated: () => {
+    clearInterval(exportLinkInterval);
+    exportLinkInterval = setInterval(addExportLink, 1000);
+  },
+  onDeactivated: () => {
+    clearInterval(exportLinkInterval);
+  },
+});

--- a/src/pages/content/mint-navigation.ts
+++ b/src/pages/content/mint-navigation.ts
@@ -1,0 +1,79 @@
+import { getElement } from './get-element';
+
+type Section =
+  | 'overview'
+  | 'transactions'
+  | 'creditscore'
+  | 'bills'
+  | 'budgets'
+  | 'goals'
+  | 'trends'
+  | 'investments'
+  | 'marketplace'
+  | 'settings';
+
+class SectionChangeEvent extends Event {
+  constructor(public readonly section: Section) {
+    super('change');
+  }
+}
+
+class ActiveSection extends EventTarget {
+  #activeSection: Section;
+
+  get activeSection() {
+    return this.#activeSection;
+  }
+
+  set activeSection(section: Section) {
+    if (section && this.#activeSection !== section) {
+      this.#activeSection = section;
+      this.dispatchEvent(new SectionChangeEvent(section));
+    }
+  }
+}
+const sectionObserver = new ActiveSection();
+
+/** Run setup and teardown code based on the active top-level menu section in Mint. */
+export const whenMintSectionActive = ({
+  section,
+  onActivated,
+  onDeactivated,
+}: {
+  section: Section;
+  onActivated: () => void;
+  onDeactivated: () => void;
+}) => {
+  let isActive = sectionObserver.activeSection === section;
+  if (isActive) {
+    onActivated();
+  }
+  sectionObserver.addEventListener('change', (event: SectionChangeEvent) => {
+    if (section === event.section) {
+      isActive = true;
+      onActivated();
+    } else if (isActive) {
+      isActive = false;
+      onDeactivated();
+    }
+  });
+};
+
+// Watch the active menu item
+(async () => {
+  const nav = await getElement('.smart-money-app-left-nav nav ul');
+  const updateActiveSection = () => {
+    sectionObserver.activeSection = nav
+      .querySelector('li[class*="selected"] a')
+      ?.getAttribute('data-auto-sel')
+      ?.replace('nav-', '') as Section;
+  };
+  const observer = new MutationObserver(updateActiveSection);
+  observer.observe(nav, {
+    attributes: true,
+    attributeFilter: ['class'],
+    childList: true,
+    subtree: true,
+  });
+  updateActiveSection();
+})();

--- a/src/pages/content/trend-state.ts
+++ b/src/pages/content/trend-state.ts
@@ -24,7 +24,8 @@ export const isSupportedTrendReport = (type: ReportType) => {
     case 'SPENDING_TIME':
     case 'NET_INCOME':
     case 'NET_WORTH':
-      return true;
+      // Disable when filtered by category, tag, etc. because this filter is not in the trend state
+      return !document.querySelector('[data-automation-id="filter-chip"]');
     default:
       // by tag, by category, by type, etc.
       return false;

--- a/src/pages/content/trend-state.ts
+++ b/src/pages/content/trend-state.ts
@@ -1,0 +1,32 @@
+import { TrendType, TrendState, ReportType } from '../../shared/lib/accounts';
+
+const CURRENT_TREND_TYPE_LOCAL_STORAGE_KEY = 'trends-state';
+
+const getCurrentTrendType = () => {
+  return localStorage.getItem(CURRENT_TREND_TYPE_LOCAL_STORAGE_KEY) as TrendType;
+};
+
+const getTrendState = (type: TrendType) => {
+  return JSON.parse(
+    localStorage.getItem(`${CURRENT_TREND_TYPE_LOCAL_STORAGE_KEY}-${type}`) || 'null',
+  ) as TrendState;
+};
+
+/** State for the most recent trend according to localStorage, does not need to be visible */
+export const getCurrentTrendState = () => getTrendState(getCurrentTrendType());
+
+/** Whether the extension can generate daily balances for the active trend. */
+export const isSupportedTrendReport = (type: ReportType) => {
+  switch (type) {
+    case 'ASSETS_TIME':
+    case 'DEBTS_TIME':
+    case 'INCOME_TIME':
+    case 'SPENDING_TIME':
+    case 'NET_INCOME':
+    case 'NET_WORTH':
+      return true;
+    default:
+      // by tag, by category, by type, etc.
+      return false;
+  }
+};

--- a/src/shared/hooks/useMessage.ts
+++ b/src/shared/hooks/useMessage.ts
@@ -13,13 +13,16 @@ export enum Action {
   DebugThrowError = 'DEBUG_THROW_ERROR',
 }
 
-type Message = { action: Action; payload?: Record<string, unknown> };
+export type Message<TPayload = Record<string, unknown>> = {
+  action: Action;
+  payload?: TPayload
+};
 
 export const useMessageListener = <TPayload extends Record<string, unknown>>(
   action: Action,
   callback: (payload: TPayload) => void | Promise<void>,
 ) => {
-  const listenerRef = useRef<(message: Message, sender: unknown, sendResponse: unknown) => void>();
+  const listenerRef = useRef<(message: Message<TPayload>, sender: unknown, sendResponse: unknown) => void>();
 
   useEffect(() => {
     if (listenerRef.current) {
@@ -31,9 +34,9 @@ export const useMessageListener = <TPayload extends Record<string, unknown>>(
       if (message.action === action) {
         // eslint-disable-next-line no-prototype-builtins
         if (callback.hasOwnProperty('then')) {
-          await callback(message.payload as TPayload);
+          await callback(message.payload);
         } else {
-          callback(message.payload as TPayload);
+          callback(message.payload);
         }
       }
 

--- a/src/shared/hooks/useMessage.ts
+++ b/src/shared/hooks/useMessage.ts
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useCallback } from 'react';
+import { ContentAction } from '../../pages/content/content-action';
 
 export enum Action {
   PopupOpened = 'POPUP_OPENED',
@@ -14,7 +15,7 @@ export enum Action {
 }
 
 export type Message<TPayload = Record<string, unknown>> = {
-  action: Action;
+  action: Action | ContentAction;
   payload?: TPayload
 };
 

--- a/src/shared/lib/__tests__/accounts.test.ts
+++ b/src/shared/lib/__tests__/accounts.test.ts
@@ -168,6 +168,110 @@ describe('formatBalancesAsCSV', () => {
 "2020-01-01","0"
 `);
   });
+
+  it('handles net income balances', () => {
+    const result = formatBalancesAsCSV({
+      reportType: 'NET_INCOME',
+      balances: [
+        {
+          amount: 0,
+          date: '2020-01-01',
+          type: 'INCOME',
+        },
+        {
+          amount: 123.45,
+          date: '2020-01-01',
+          type: 'EXPENSE',
+        },
+        {
+          amount: 43.21,
+          date: '2020-01-02',
+          type: 'INCOME',
+        },
+        {
+          amount: 234.56,
+          date: '2020-01-03',
+          type: 'INCOME',
+        },
+      ],
+    });
+    expect(result).toEqual(`"Date","Income","Expenses","Net"
+"2020-01-01","0","123.45","-123.45"
+"2020-01-02","43.21","0","43.21"
+"2020-01-03","234.56","0","234.56"
+`);
+  });
+
+  it('trims trailing zero net income balances', () => {
+    const result = formatBalancesAsCSV({
+      reportType: 'NET_INCOME',
+      balances: [
+        {
+          amount: 0,
+          date: '2020-01-01',
+          type: 'INCOME',
+        },
+        {
+          amount: 123.45,
+          date: '2020-01-01',
+          type: 'EXPENSE',
+        },
+        {
+          amount: 0,
+          date: '2020-01-02',
+          type: 'INCOME',
+        },
+        {
+          amount: 0,
+          date: '2020-01-03',
+          type: 'INCOME',
+        },
+      ],
+    });
+    expect(result).toEqual(`"Date","Income","Expenses","Net"
+"2020-01-01","0","123.45","-123.45"
+`);
+  });
+
+  it('fixes floating point subtraction in net income balances', () => {
+    const result = formatBalancesAsCSV({
+      reportType: 'NET_INCOME',
+      balances: [
+        {
+          amount: 123.45,
+          date: '2020-01-01',
+          type: 'INCOME',
+        },
+        {
+          amount: 12.35,
+          date: '2020-01-01',
+          type: 'EXPENSE',
+        },
+      ],
+    });
+    // Not 111.10000000000001
+    expect(result).toEqual(`"Date","Income","Expenses","Net"
+"2020-01-01","123.45","12.35","111.10"
+`);
+  });
+
+  it('represents zero in the Net column as 0.00', () => {
+    // as a consequence of toFixed(2)
+    const result = formatBalancesAsCSV({
+      reportType: 'NET_INCOME',
+      balances: [
+        {
+          amount: 0,
+          date: '2020-01-01',
+          type: 'INCOME',
+        },
+      ],
+    });
+    // Not 111.10000000000001
+    expect(result).toEqual(`"Date","Income","Expenses","Net"
+"2020-01-01","0","0","0.00"
+`);
+  });
 });
 
 describe('fetchDailyBalancesForAllAccounts', () => {

--- a/src/shared/lib/__tests__/accounts.test.ts
+++ b/src/shared/lib/__tests__/accounts.test.ts
@@ -72,13 +72,13 @@ describe('fetchTrendAccounts', () => {
 
 describe('formatBalancesAsCSV', () => {
   it('includes account name if provied', () => {
-    const result = formatBalancesAsCSV(
-      [
-        { amount: 123.45, date: '2021-01-01', type: '' },
-        { amount: 234.56, date: '2021-02-01', type: '' },
+    const result = formatBalancesAsCSV({
+      balances: [
+        { amount: 123.45, date: '2021-01-01', type: 'ASSET' },
+        { amount: 234.56, date: '2021-02-01', type: 'ASSET' },
       ],
-      `Mason's Account`,
-    );
+      accountName: `Mason's Account`,
+    });
     expect(result).toEqual(`"Date","Amount","Account Name"
 "2021-01-01","123.45","Mason's Account"
 "2021-02-01","234.56","Mason's Account"
@@ -86,10 +86,12 @@ describe('formatBalancesAsCSV', () => {
   });
 
   it('does not include account name if not provided', () => {
-    const result = formatBalancesAsCSV([
-      { amount: 123.45, date: '2021-01-01', type: '' },
-      { amount: 234.56, date: '2021-02-01', type: '' },
-    ]);
+    const result = formatBalancesAsCSV({
+      balances: [
+        { amount: 123.45, date: '2021-01-01', type: 'ASSET' },
+        { amount: 234.56, date: '2021-02-01', type: 'ASSET' },
+      ],
+    });
     expect(result).toEqual(`"Date","Amount"
 "2021-01-01","123.45"
 "2021-02-01","234.56"
@@ -97,41 +99,45 @@ describe('formatBalancesAsCSV', () => {
   });
 
   it('converts undefined balances to empty string', () => {
-    const result = formatBalancesAsCSV([
-      {
-        amount: undefined,
-        date: '2020-01-01',
-        type: '',
-      },
-    ]);
+    const result = formatBalancesAsCSV({
+      balances: [
+        {
+          amount: undefined,
+          date: '2020-01-01',
+          type: 'ASSET',
+        },
+      ],
+    });
     expect(result).toEqual(`"Date","Amount"
 "2020-01-01",""
 `);
   });
 
   it('trims trailing zero balances', () => {
-    const result = formatBalancesAsCSV([
-      {
-        amount: 123.45,
-        date: '2020-01-01',
-        type: '',
-      },
-      {
-        amount: 234.56,
-        date: '2020-01-02',
-        type: '',
-      },
-      {
-        amount: 0,
-        date: '2020-01-03',
-        type: '',
-      },
-      {
-        amount: 0,
-        date: '2020-01-04',
-        type: '',
-      },
-    ]);
+    const result = formatBalancesAsCSV({
+      balances: [
+        {
+          amount: 123.45,
+          date: '2020-01-01',
+          type: 'ASSET',
+        },
+        {
+          amount: 234.56,
+          date: '2020-01-02',
+          type: 'ASSET',
+        },
+        {
+          amount: 0,
+          date: '2020-01-03',
+          type: 'ASSET',
+        },
+        {
+          amount: 0,
+          date: '2020-01-04',
+          type: 'ASSET',
+        },
+      ],
+    });
     expect(result).toEqual(`"Date","Amount"
 "2020-01-01","123.45"
 "2020-01-02","234.56"
@@ -139,23 +145,25 @@ describe('formatBalancesAsCSV', () => {
   });
 
   it('leaves one row if all balances are zero', () => {
-    const result = formatBalancesAsCSV([
-      {
-        amount: 0,
-        date: '2020-01-01',
-        type: '',
-      },
-      {
-        amount: 0,
-        date: '2020-01-02',
-        type: '',
-      },
-      {
-        amount: 0,
-        date: '2020-01-03',
-        type: '',
-      },
-    ]);
+    const result = formatBalancesAsCSV({
+      balances: [
+        {
+          amount: 0,
+          date: '2020-01-01',
+          type: 'ASSET',
+        },
+        {
+          amount: 0,
+          date: '2020-01-02',
+          type: 'ASSET',
+        },
+        {
+          amount: 0,
+          date: '2020-01-03',
+          type: 'ASSET',
+        },
+      ],
+    });
     expect(result).toEqual(`"Date","Amount"
 "2020-01-01","0"
 `);
@@ -175,16 +183,16 @@ describe('fetchDailyBalancesForAllAccounts', () => {
 describe('calculateIntervalForAccountHistory', () => {
   it('starts at the first day of the first month with history', () => {
     const result = calculateIntervalForAccountHistory([
-      { date: '2023-01-31', amount: 5, type: '' },
-      { date: '2023-02-28', amount: 10, type: '' },
+      { date: '2023-01-31', amount: 5, type: 'ASSET' },
+      { date: '2023-02-28', amount: 10, type: 'ASSET' },
     ]);
     expect(result.start.toISODate()).toBe('2023-01-01');
   });
 
   it('ends today for nonzero balances', () => {
     const result = calculateIntervalForAccountHistory([
-      { date: '2023-01-31', amount: 5, type: '' },
-      { date: '2023-02-28', amount: 10, type: '' },
+      { date: '2023-01-31', amount: 5, type: 'ASSET' },
+      { date: '2023-02-28', amount: 10, type: 'ASSET' },
     ]);
     expect(result.end.toISODate()).toBe(DateTime.now().toISODate());
   });
@@ -192,28 +200,28 @@ describe('calculateIntervalForAccountHistory', () => {
   it('ends today even if the data goes beyond today', () => {
     const nextMonth = DateTime.now().plus({ month: 1 }).endOf('month').toISODate();
     const result = calculateIntervalForAccountHistory([
-      { date: '2023-01-31', amount: 5, type: '' },
-      { date: nextMonth, amount: 10, type: '' },
+      { date: '2023-01-31', amount: 5, type: 'ASSET' },
+      { date: nextMonth, amount: 10, type: 'ASSET' },
     ]);
     expect(result.end.toISODate()).toBe(DateTime.now().toISODate());
   });
 
   it('ends 1 month after the last historic nonzero monthly balance', () => {
     const result = calculateIntervalForAccountHistory([
-      { date: '2023-01-31', amount: 5, type: '' },
-      { date: '2023-02-28', amount: 10, type: '' },
-      { date: '2023-03-31', amount: 0, type: '' },
+      { date: '2023-01-31', amount: 5, type: 'ASSET' },
+      { date: '2023-02-28', amount: 10, type: 'ASSET' },
+      { date: '2023-03-31', amount: 0, type: 'ASSET' },
     ]);
     expect(result.end.toISODate()).toBe('2023-03-31');
   });
 
   it('ends 1 month after the last historic nonzero monthly balance', () => {
     const result = calculateIntervalForAccountHistory([
-      { date: '2023-01-31', amount: 5, type: '' },
-      { date: '2023-02-28', amount: 10, type: '' },
-      { date: '2023-03-31', amount: 0, type: '' },
-      { date: '2023-04-30', amount: 0, type: '' },
-      { date: '2023-05-31', amount: 0, type: '' },
+      { date: '2023-01-31', amount: 5, type: 'ASSET' },
+      { date: '2023-02-28', amount: 10, type: 'ASSET' },
+      { date: '2023-03-31', amount: 0, type: 'ASSET' },
+      { date: '2023-04-30', amount: 0, type: 'ASSET' },
+      { date: '2023-05-31', amount: 0, type: 'ASSET' },
     ]);
     expect(result.end.toISODate()).toBe('2023-03-31');
   });
@@ -222,10 +230,10 @@ describe('calculateIntervalForAccountHistory', () => {
     // No need for a special case here, the interval is 2 months because we always add 1 month for
     // safety to the last month worth including in the report.
     const result = calculateIntervalForAccountHistory([
-      { date: '2023-01-31', amount: 0, type: '' },
-      { date: '2023-02-28', amount: 0, type: '' },
-      { date: '2023-03-31', amount: 0, type: '' },
-      { date: '2023-04-30', amount: 0, type: '' },
+      { date: '2023-01-31', amount: 0, type: 'ASSET' },
+      { date: '2023-02-28', amount: 0, type: 'ASSET' },
+      { date: '2023-03-31', amount: 0, type: 'ASSET' },
+      { date: '2023-04-30', amount: 0, type: 'ASSET' },
     ]);
     expect(result.start.toISODate()).toBe('2023-01-01');
     expect(result.end.toISODate()).toBe('2023-02-28');

--- a/src/shared/lib/__tests__/accounts.test.ts
+++ b/src/shared/lib/__tests__/accounts.test.ts
@@ -5,6 +5,7 @@ import {
   fetchDailyBalancesForAllAccounts,
   fetchMonthlyBalancesForAccount,
   fetchNetWorthBalances,
+  fetchTrendAccounts,
   formatBalancesAsCSV,
 } from '../accounts';
 import { DateTime } from 'luxon';
@@ -40,6 +41,32 @@ describe('fetchAccounts', () => {
       overrideApiKey: TEST_MINT_API_KEY,
     });
     expect(accounts.length).toEqual(35);
+  });
+});
+
+describe('fetchTrendAccounts', () => {
+  it('excludes deselected accounts', async () => {
+    const allDebtAccounts = await fetchTrendAccounts({
+      trend: {
+        reportType: 'DEBTS_TIME',
+        deselectedAccountIds: [],
+        fixedFilter: 'CUSTOM',
+        fromDate: '2020-01-01',
+        toDate: '2020-01-01',
+      },
+      overrideApiKey: TEST_MINT_API_KEY,
+    });
+    const accounts = await fetchTrendAccounts({
+      trend: {
+        reportType: 'DEBTS_TIME',
+        deselectedAccountIds: ['43237333_2630847'], // a debt account
+        fixedFilter: 'CUSTOM',
+        fromDate: '2020-01-01',
+        toDate: '2020-01-01',
+      },
+      overrideApiKey: TEST_MINT_API_KEY,
+    });
+    expect(accounts.length).toEqual(allDebtAccounts.length - 1);
   });
 });
 

--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -15,12 +15,37 @@ import {
   withRateLimit,
 } from '@root/src/shared/lib/promises';
 
+export type AccountCategory = 'DEBT' | 'ASSET';
+
+export type TrendType = 'DEBT' | 'ASSET' | 'INCOME' | 'EXPENSE';
+
+export type ReportType =
+  | 'ASSETS_TIME'
+  | 'DEBTS_TIME'
+  | 'SPENDING_TIME'
+  | 'INCOME_TIME'
+  | 'NET_INCOME'
+  | 'NET_WORTH';
+
+export type FixedDateFilter =
+  | 'LAST_7_DAYS'
+  | 'LAST_14_DAYS'
+  | 'THIS_MONTH'
+  | 'LAST_MONTH'
+  | 'LAST_3_MONTHS'
+  | 'LAST_6_MONTHS'
+  | 'LAST_12_MONTHS'
+  | 'THIS_YEAR'
+  | 'LAST_YEAR'
+  | 'ALL_TIME'
+  | 'CUSTOM';
+
 type TrendEntry = {
   amount: number;
   date: string;
   // this is determined by the type of report we fetch (DEBTS_TIME/ASSETS_TIME)
   // it will return different values if we decide to fetch more types of reports (e.g., SPENDING_TIME)
-  type: 'DEBT' | 'ASSET' | string;
+  type: TrendType;
 };
 
 type TrendsResponse = {
@@ -37,6 +62,28 @@ export type BalanceHistoryProgressCallback = (progress: {
 export type BalanceHistoryCallbackProgress = Parameters<BalanceHistoryProgressCallback>[0];
 
 type ProgressCallback = (progress: { complete: number; total: number }) => void | Promise<void>;
+
+const ACCOUNT_CATEGORY_BY_ACCOUNT_TYPE = {
+  BankAccount: 'ASSET',
+  CashAccount: 'ASSET',
+  CreditAccount: 'DEBT',
+  InsuranceAccount: 'ASSET',
+  InvestmentAccount: 'ASSET',
+  LoanAccount: 'DEBT',
+  RealEstateAccount: 'ASSET',
+  VehicleAccount: 'ASSET',
+  OtherPropertyAccount: 'ASSET',
+} satisfies Record<string, AccountCategory>;
+
+type AccountType = keyof typeof ACCOUNT_CATEGORY_BY_ACCOUNT_TYPE;
+
+type AccountsResponse = {
+  Account: {
+    type: AccountType;
+    id: string;
+    name: string;
+  }[];
+};
 
 /**
  * Use internal Mint "Trends" API to fetch account balance by month
@@ -326,14 +373,6 @@ const fetchTrends = ({
     },
     overrideApiKey,
   );
-
-type AccountsResponse = {
-  Account: {
-    type: string;
-    id: string;
-    name: string;
-  }[];
-};
 
 /**
  * Use internal Mint API to fetch all of user's accounts.

--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -81,7 +81,8 @@ export type TrendBalanceHistoryProgressCallback = (progress: {
   completePercentage: number;
 }) => void | Promise<void>;
 
-export type TrendBalanceHistoryCallbackProgress = Parameters<TrendBalanceHistoryProgressCallback>[0];
+export type TrendBalanceHistoryCallbackProgress =
+  Parameters<TrendBalanceHistoryProgressCallback>[0];
 
 type ProgressCallback = (progress: { complete: number; total: number }) => void | Promise<void>;
 
@@ -90,7 +91,7 @@ type AccountIdFilter = {
   accountId: string;
 };
 
-const ACCOUNT_CATEGORY_BY_ACCOUNT_TYPE = {
+export const ACCOUNT_CATEGORY_BY_ACCOUNT_TYPE = {
   BankAccount: 'ASSET',
   CashAccount: 'ASSET',
   CreditAccount: 'DEBT',
@@ -102,7 +103,13 @@ const ACCOUNT_CATEGORY_BY_ACCOUNT_TYPE = {
   OtherPropertyAccount: 'ASSET',
 } satisfies Record<string, AccountCategory>;
 
-type AccountType = keyof typeof ACCOUNT_CATEGORY_BY_ACCOUNT_TYPE;
+export type AccountType = keyof typeof ACCOUNT_CATEGORY_BY_ACCOUNT_TYPE;
+
+export const PROPERTY_ACCOUNT_TYPES: AccountType[] = [
+  'OtherPropertyAccount',
+  'RealEstateAccount',
+  'VehicleAccount',
+];
 
 type AccountTypeFilter = (accountType: AccountType) => boolean;
 
@@ -134,10 +141,8 @@ export const getAccountTypeFilterForTrend = (trend: TrendState): AccountTypeFilt
       return (type) => ACCOUNT_CATEGORY_BY_ACCOUNT_TYPE[type] === 'DEBT';
     case 'NET_INCOME':
       return (type) =>
-        type !== 'VehicleAccount' &&
-        type !== 'RealEstateAccount' &&
-        type !== 'OtherPropertyAccount' &&
         type !== 'InsuranceAccount' &&
+        !PROPERTY_ACCOUNT_TYPES.includes(type) &&
         // Cash account does not appear in the dropdown; it is included only when All Accounts are
         // selected not when specific accounts are selected
         // TODO: verify this isn't just on idpaterson's account

--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -508,6 +508,10 @@ export const fetchTrendAccounts = async ({
 }: {
   trend: TrendState;
 } & FetchAccountsOptions) => {
+  // Mint knows best which accounts are eligible for the trend if nothing is selected
+  if (!trend.deselectedAccountIds?.length) {
+    return [];
+  }
   const allAccounts = await fetchAccounts({ offset: 0, ...options });
   const accountTypeFilter = getAccountTypeFilterForTrend(trend);
 

--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -169,11 +169,7 @@ const fetchDailyBalancesForAccount = async ({
               dateFilter: {
                 type: 'CUSTOM',
                 startDate: start.toISODate(),
-                // end is really the start of the next month, so subtract one day
-                endDate:
-                  end < DateTime.now()
-                    ? end.minus({ day: 1 }).toISODate()
-                    : DateTime.now().toISODate(),
+                endDate: end < DateTime.now() ? end.toISODate() : DateTime.now().toISODate(),
               },
               overrideApiKey,
             })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,6 +55,8 @@ export default defineConfig({
     rollupOptions: {
       input: {
         background: resolve(pagesDir, 'background', 'index.ts'),
+        content: resolve(pagesDir, 'content', 'index.ts'),
+        'content-bootstrap': resolve(pagesDir, 'content', 'bootstrap.ts'),
         popup: resolve(pagesDir, 'popup', 'index.html'),
       },
       output: {


### PR DESCRIPTION
This update ports over the "Export Daily History to CSV" button from [my userscript](https://gist.github.com/idpaterson/89ce0cbc6e578a9398257debd1898555) now leveraging the API framework of Monarch's extension along with several other enhancements. The button appears next to the Mint Export button at the bottom of the Trends page.

<img 
    src="https://user-images.githubusercontent.com/507058/282305459-f013d151-2906-45e9-a892-9fb138e0006b.gif" 
    alt="Export Daily History to CSV button screen recording"
    width="311"
/>

I attempted to split this PR into fairly bite-sized commits to aid review. Since I was committing retroactively there may be a few commits that do not build on their own if I didn't grab enough code.

## Export any time-based trend

The fetch functions have been generalized to work for any time-based trend which is pretty much just passing in a report type and a list of accounts that become filters. When working with trend state the extension fetches the daily balances for the exact time period you're looking at – no optimization to avoid fetching zero months. I had it in the original userscript but since the popup is such a nicer way to export all accounts I think the use cases for trend exporting would not demand that kind of optimization. Just use a custom date range if you're concerned about loading too much data 😉 

The `formatBalancesAsCSV` function now supports the oddball net worth and net income trends that include extra columns. `zipTrendEntries()` handles the API response for those trends since they can contain two `TrendEntry` rows per date. Same trimming of zero values at the end of the CSV for all trend types.

## Making API requests correspond to Mint trend state

Okay, so... `localStorage.trends-state-ASSETS` and friends track the current state of the user's selections on the Trend page. As a user I select the accounts that I want to see but `localStorage.trends-state-*` lists only `deselectedAccounts`. The concept of "all accounts" differs based on the report type so it's inconvenient that we only know which are deselected. 

Weird, but no problem since the trends API seems to support affirmative and negative filters `[{ matchAll: true, filters: [...] }, { matchAll: false, filters: [...] }]`. Except, taking that `deselectedAccounts` value and plugging it in to the `matchAll: false` filters results in a 400 bad request. I tried everything I could think of but was not able to figure out if the API supports filtering based on the deselected accounts.

So, `getAccountTypeFilterForTrend()` was born. We now have a mapping `ACCOUNT_CATEGORY_BY_ACCOUNT_TYPE` of all account types (from an enum in the Mint source) to category (asset or debt). That seems to work for most of the report types to determine which accounts are eligible but `NET_INCOME` is a special little darling. 

It would be great if someone can carefully review how the logic in `getAccountTypeFilterForTrend()` compares to actual trend data, particularly for `CashAccount`. To test this I was using the "Last Month" range on Net Income, selecting a subset of accounts, and comparing the numbers in the CSV to the Trends table. The current implementation seems to be correct for my account. I do not have a "Cash" account in the Trends dropdown, it shows up in the accounts API response and it has data but I can't select it. The Cash account **is** included when I choose "All accounts" on the Net Income trend. (see [comment](https://github.com/monarchmoney/mint-export-extension/pull/23#issuecomment-1817550046) for more details on the implementation)

Feel free to comment out a few report types in `isSupportedTrendReport()` if this is too much to test right now. You guys have been great but I realize this may be more than you signed up for. The button is visible but disabled for unsupported trends like "spending by tag."

## Watching for the Trends page

The script uses a `MutationObserver` on the Mint main menu to determine when the Trends page is active. This gates the code that inserts the export button, so when we're not on the Trends page the content script is not doing anything. When on the Trends page the script just checks every couple seconds to make sure the button is still in the DOM since Mint removes it when the trend changes, definitely not worth trying to target specific interactions that cause it to be removed.

## Vite config

I suspect that there is a better way to configure this, but I ran out of patience trying to get it to work. Content scripts do not support ES module syntax so there is a bootstrap script that loads the actual content script – otherwise I would have had to find a way to change how the content script is built or put everything in one big file 😨. 

It nearly ends up as one big file in the build so the bootstrap would not be necessary except that the `ContentAction` enum is still a separate import statement. I don't know why that happens but it could probably be simplified, maybe something about importing the same file into the service worker. Also, maybe the entire content script should be in assets/js but I couldn't figure that out either.