### PR TITLE
Add financial institution name to balance history csv files

### DIFF
--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -166,11 +166,11 @@ const handleDownloadAllAccountBalances = async (sendResponse: () => void) => {
     // combine CSV for each account into one zip file
     const zip = new JSZip();
     const seenAccountNames = {};
-    successAccounts.forEach(({ accountName, balances }) => {
+    successAccounts.forEach(({ accountName, fiName, balances }) => {
       const seenCount = (seenAccountNames[accountName] = (seenAccountNames[accountName] || 0) + 1);
       // If there are multiple accounts with the same name, export both with distinct filenames
       const disambiguation = seenCount > 1 ? ` (${seenCount - 1})` : '';
-      zip.file(`${accountName}${disambiguation}.csv`, formatBalancesAsCSV(balances, accountName));
+      zip.file(`${accountName}${disambiguation}-${fiName}.csv`, formatBalancesAsCSV(balances, accountName));
     });
 
     const zipFile = await zip.generateAsync({ type: 'base64' });


### PR DESCRIPTION
The account data from Mint includes a "fiName" that contains the financial institution's name. This change maps that field and includes it at the end of the resulting file names. This can be incredibly helpful while importing the blance histories into their respective accounts when account names are very similar, or even identical.