### PR TITLE
Adaptive rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "construct-style-sheets-polyfill": "^3.1.0",
     "jszip": "3.10.1",
     "luxon": "3.4.3",
+    "p-ratelimit": "^1.0.1",
     "pluralize": "^8.0.0",
     "postcss": "^8.4.31",
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -29,6 +29,9 @@ dependencies:
   luxon:
     specifier: 3.4.3
     version: 3.4.3
+  p-ratelimit:
+    specifier: ^1.0.1
+    version: 1.0.1
   pluralize:
     specifier: ^8.0.0
     version: 8.0.0
@@ -6345,6 +6348,11 @@ packages:
     dependencies:
       p-limit: 4.0.0
     dev: true
+
+  /p-ratelimit@1.0.1:
+    resolution: {integrity: sha512-tKBGoow6aWRH68K2eQx+qc1gSegjd5VLirZYc1Yms9pPFsYQ9TFI6aMn0vJH2vmvzjNpjlWZOFft4aPUen2w0A==}
+    engines: {node: '>=10.23.0'}
+    dev: false
 
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}

--- a/src/shared/lib/__tests__/promises.test.ts
+++ b/src/shared/lib/__tests__/promises.test.ts
@@ -9,7 +9,7 @@ describe('withRateLimit', () => {
     };
 
     const startTime = new Date().getTime();
-    await withRateLimit({ delayMs: 500 })([request, request, request]);
+    await withRateLimit({ rate: 2 })([request, request, request]);
     const endTime = new Date().getTime();
 
     expect(endTime - startTime).toBeGreaterThan(1000);

--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -204,8 +204,8 @@ export const fetchDailyBalancesForAllAccounts = async ({
   const accounts = await withRetry(() => fetchAccounts({ overrideApiKey }));
 
   // first, fetch the range of dates we need to fetch for each account
-  const accountsWithPeriodsToFetch = await Promise.all(
-    accounts.map(async ({ id: accountId, name: accountName }) => {
+  const accountsWithPeriodsToFetch = await withRateLimit()(
+    accounts.map(({ id: accountId, name: accountName }) => async () => {
       const { periods, reportType } = await withDefaultOnError({ periods: [], reportType: '' })(
         fetchIntervalsForAccountHistory({
           accountId,

--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -5,7 +5,6 @@ import {
   DATE_FILTER_ALL_TIME,
   MINT_DAILY_TRENDS_MAX_DAYS,
   MINT_HEADERS,
-  MINT_RATE_LIMIT_DELAY_MS,
 } from '@root/src/shared/lib/constants';
 import { formatCSV } from '@root/src/shared/lib/csv';
 import { withRetry } from '@root/src/shared/lib/retry';
@@ -158,7 +157,7 @@ const fetchDailyBalancesForAccount = async ({
     count: 0,
   };
 
-  const dailyBalancesByPeriod = await withRateLimit({ delayMs: MINT_RATE_LIMIT_DELAY_MS })(
+  const dailyBalancesByPeriod = await withRateLimit()(
     periods.map(
       ({ start, end }) =>
         () =>

--- a/src/shared/lib/constants.ts
+++ b/src/shared/lib/constants.ts
@@ -12,8 +12,11 @@ export const UTM_URL_PARAMETERS = {
   utm_source: 'mint_export_extension',
 };
 
-// we may need to increase this, need to test more
-export const MINT_RATE_LIMIT_DELAY_MS = 50;
+/** Default number of API requests that can start in each 1 second window */
+export const MINT_RATE_LIMIT_REQUESTS_PER_SECOND = 20;
+
+/** Default number of API requests that can run at the same time */
+export const MINT_RATE_LIMIT_CONCURRENT_REQUESTS = 6;
 
 // The Mint API returns daily activity when the date range is 43 days or fewer.
 export const MINT_DAILY_TRENDS_MAX_DAYS = 43;

--- a/src/shared/lib/promises.ts
+++ b/src/shared/lib/promises.ts
@@ -1,30 +1,46 @@
-import delay from '@root/src/shared/lib/delay';
+import { pRateLimit, Quota } from 'p-ratelimit';
+import {
+  MINT_RATE_LIMIT_CONCURRENT_REQUESTS,
+  MINT_RATE_LIMIT_REQUESTS_PER_SECOND,
+} from './constants';
 
-type RateLimitOptions = {
-  /** Delay between when each request is started. Does not wait for request to finish. */
-  delayMs: number;
-};
+type RateLimitOptions = Quota;
 
 /**
  * Like Promise.all, except with requests spaced out.
  *
- * Usage:
- * await withRateLimit({ delayMs: 50 })([
+ * The default interval is 1 second, so {@link RateLimitOptions.rate} is in terms of requests per
+ * second. The default {@link RateLimitOptions.rate} is {@link MINT_RATE_LIMIT_REQUESTS_PER_SECOND}
+ * and the default {@link RateLimitOptions.concurrency} option is
+ * {@link MINT_RATE_LIMIT_CONCURRENT_REQUESTS}.
+ *
+ * The concurrency limit once reached ensures that the next request does not begin until a previous
+ * request has completed.
+ *
+ * Usage for 5 requests per second:
+ * await withRateLimit({ rate: 5 })([
  *  () => request(),
  *  () => request(),
  * ])
  */
 export const withRateLimit =
-  (options: RateLimitOptions) =>
+  (options?: RateLimitOptions) =>
   async <T>(requests: (() => Promise<T>)[]): Promise<T[]> => {
-    const { delayMs } = options;
+    const limit = pRateLimit({
+      interval: 1000,
+      rate: MINT_RATE_LIMIT_REQUESTS_PER_SECOND,
+      concurrency: MINT_RATE_LIMIT_CONCURRENT_REQUESTS,
+      ...options,
+    });
+    let cancelled = false;
 
     return Promise.all(
-      requests.map(async (request, i) => {
-        await delay(i * delayMs);
-        return request();
-      }),
-    );
+      // if Promise.all rejects, stop all remaining requests
+      requests.map((request) => limit(() => (cancelled ? Promise.reject() : request()))),
+    ).catch((e) => {
+      cancelled = true;
+      throw e;
+    });
   };
 
 /**


### PR DESCRIPTION
This pull request implements rate limiting that will adapt to latency in the Mint API. The extension will issue up to 20 requests per second with no more than 6 active at any given time. I recommend doing some testing to tweak those numbers, it may be possible to issue more requests but this default seemed respectful to the API.

Fixes #29. The [current implementation of withRateLimit](https://github.com/monarchmoney/mint-export-extension/blob/1aa8ffc64a584950cba70e68008bed90d74ba8e3/src/shared/lib/promises.ts#L17-L28) schedules all requests for an account to begin at 50ms intervals regardless of how long it takes the Mint API to respond. If the responses take more than a few milliseconds we end up with numerous concurrent requests. Once flooded like that, since the Mint API uses HTTP/2 the browser may not impose a maximum number of connections and the Mint API is likely to rate limit the requests.

When exporting daily account balances the requests to get the monthly history for each account are now rate limited as well. Otherwise the extension kicks off one request for every account all at essentially the same time.

This PR will make exporting a little slower when the Mint API is fast, but it increases the chances that export will continue to work when the API is bogged down.