### PR TITLE
Count retried requests toward progress only once

### DIFF
--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -173,20 +173,18 @@ const fetchDailyBalancesForAccount = async ({
               },
               overrideApiKey,
             })
-              .then((response) =>
-                response.json().then(({ Trend }) =>
-                  Trend.map(({ amount, type, ...rest }) => ({
-                    ...rest,
-                    type,
-                    amount: type === 'DEBT' ? -amount : amount,
-                  })),
-                ),
-              )
-              .finally(() => {
-                counter.count += 1;
-                onProgress?.({ complete: counter.count, total: periods.length });
-              }),
-          ),
+              .then((response) => response.json())
+              .then(({ Trend }) =>
+                Trend.map(({ amount, type, ...rest }) => ({
+                  ...rest,
+                  type,
+                  amount: type === 'DEBT' ? -amount : amount,
+                })),
+              ),
+          ).finally(() => {
+            counter.count += 1;
+            onProgress?.({ complete: counter.count, total: periods.length });
+          }),
     ),
   );
 


### PR DESCRIPTION
When the Mint API is struggling, requests may fail and need to be retried. Previously when this occurred the progress bar reflected each retry as a completed request and progress could exceed 100%. This change moves the progress tracking outside of `withRetry()` so that each request is counted only once even if it has to be issued several times before succeeding or reaching the max retry limit.