### PR TITLE
Show progress if export is already running

### DIFF
--- a/src/components/popup/PopupContainer.tsx
+++ b/src/components/popup/PopupContainer.tsx
@@ -37,6 +37,13 @@ const PopupContainer = ({ children }: React.PropsWithChildren) => {
   const sendMessage = useMessageSender();
 
   const onDownloadTransactions = useCallback(async () => {
+    const { downloadTransactionsStatus } = await stateStorage.get();
+    if (downloadTransactionsStatus === AccountsDownloadStatus.Loading) {
+      await stateStorage.patch({
+        currentPage: 'downloadTransactions',
+      });
+      return;
+    }
     await stateStorage.patch({
       currentPage: 'downloadTransactions',
       downloadTransactionsStatus: ResponseStatus.Loading,
@@ -54,6 +61,13 @@ const PopupContainer = ({ children }: React.PropsWithChildren) => {
   }, [sendMessage]);
 
   const onDownloadAccountBalanceHistory = useCallback(async () => {
+    const { status } = await accountStorage.get();
+    if (status === AccountsDownloadStatus.Loading) {
+      await stateStorage.patch({
+        currentPage: 'downloadBalances',
+      });
+      return;
+    }
     await accountStorage.clear();
 
     await stateStorage.patch({

--- a/src/components/popup/PopupContainer.tsx
+++ b/src/components/popup/PopupContainer.tsx
@@ -150,6 +150,33 @@ const PopupContainer = ({ children }: React.PropsWithChildren) => {
       ? downloadTransactionsStatus !== ResponseStatus.Loading
       : !!currentPage; // there's a page that's not index (index is undefined)
 
+  // Make sure it's actually running
+  if (currentPage === 'downloadBalances') {
+    const {
+      status,
+      progress: { completePercentage },
+    } = accountStorage.getSnapshot();
+    if (status === AccountsDownloadStatus.Loading) {
+      setTimeout(async () => {
+        const { progress } = await accountStorage.get();
+        if (completePercentage === progress.completePercentage) {
+          await accountStorage.patch({
+            status: AccountsDownloadStatus.Error,
+          });
+        }
+      }, 15_000);
+    }
+  } else if (currentPage === 'downloadTransactions') {
+    setTimeout(async () => {
+      const { downloadTransactionsStatus } = await stateStorage.get();
+      if (downloadTransactionsStatus === AccountsDownloadStatus.Loading) {
+        await stateStorage.patch({
+          downloadTransactionsStatus: AccountsDownloadStatus.Error,
+        });
+      }
+    }, 30_000);
+  }
+
   return (
     <div className="flex flex-col">
       <Section


### PR DESCRIPTION
Balance and transaction exports continue to run in the background when the popup is closed or the back button is clicked as long as Mint is still open. However, the download buttons that you see on the main popup screen clear the existing state and start a new export. Now we have two balance exports running simultaneously and the progress bar jumps erratically between the first and second export job progress.

This pull request simply shows the progress screen for those download tasks if a job is already running. Since it is possible for a job to get hung up and never finish the extension will show the error screen after a certain period of inactivity. There is probably a more idiomatic way to accomplish that than a `setTimeout()`, but it works.

The "abandoned job" state can be tested easily with the unpacked extension. 
1. Start an export for all account balance history
2. Go to `chrome://extensions` in a separate tab
3. Press the reload button next to the extension which will kill the service worker but not reset the state
4. Open the popup and wait for the error screen to appear