### PR TITLE
Eliminate duplicate dates between balance periods

### DIFF
--- a/src/shared/lib/accounts.ts
+++ b/src/shared/lib/accounts.ts
@@ -160,7 +160,7 @@ const fetchDailyBalancesForAccount = async ({
 
   const dailyBalancesByPeriod = await withRateLimit()(
     periods.map(
-      ({ start, end }) =>
+      ({ start, end }, index) =>
         () =>
           withRetry(() =>
             fetchTrends({
@@ -169,7 +169,11 @@ const fetchDailyBalancesForAccount = async ({
               dateFilter: {
                 type: 'CUSTOM',
                 startDate: start.toISODate(),
-                endDate: end < DateTime.now() ? end.toISODate() : DateTime.now().toISODate(),
+                endDate:
+                  end < DateTime.now()
+                    ? // Eliminate overlap between periods w/o losing the last day of the last period
+                      end.minus({ day: index < periods.length - 1 ? 1 : 0 }).toISODate()
+                    : DateTime.now().toISODate(),
               },
               overrideApiKey,
             })


### PR DESCRIPTION
In the latest Chrome Web Store release account balance exports include duplicate dates and therefore error out when importing into Monarch. This is a critical bug fix.

Fixes #61 which is echoed by reviews on the Chrome Web Store for the latest version. The change that I made in #22 was too focused on exporting individual months, subtracting one day from the end of the period _was_ still necessary, but only before the final period. This implementation avoids duplicate dates and to avoid regression on #22 ensures that the last day of the last period is not omitted.

P.S. GitHub is having a rough morning so I think that is why some of the checks are failing here.